### PR TITLE
Make client secret optional for credential refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .pub/
 build/
 packages
+.flutter-plugins
+.flutter-plugins-dependencies
+
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 .dart_tool
@@ -22,4 +25,3 @@ doc/api/
 *.iml
 *.ipr
 *.iws
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+- Fix credential refresh without client secret
+
 ## 0.3.0
 
 - Add hybrid flow

--- a/lib/src/openid.dart
+++ b/lib/src/openid.dart
@@ -184,12 +184,16 @@ class Credential {
   }
 
   Future refresh() async {
-      var json = await http.post(client.issuer.metadata.tokenEndpoint, body: {
+      var body = {
         "grant_type": "refresh_token",
         "refresh_token": _token.refreshToken,
         "client_id": client.clientId,
-        "client_secret": client.clientSecret,
-      });
+      };
+      if (client.clientSecret != null) {
+        body["client_secret"] = client.clientSecret;
+      }
+
+      var json = await http.post(client.issuer.metadata.tokenEndpoint, body: body);
       if (json["error"] != null) {
         throw new Exception(json["error_description"] ?? json["error"]);
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openid_client
 description: Library for working with OpenID Connect and implementing clients.
-version: 0.3.0
+version: 0.3.1
 authors:
   - Rik Bellens <rik.bellens@appsup.be>
   - Ivan Matkov <ivan.matkov@akvelon.com>


### PR DESCRIPTION
PKCE flow doesn't need client secret as part of the credential refresh request